### PR TITLE
feat: support query params passthrough

### DIFF
--- a/__tests__/__snapshots__/handlers.test.js.snap
+++ b/__tests__/__snapshots__/handlers.test.js.snap
@@ -28,6 +28,9 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {},
+    },
   ],
   Array [
     "/dev/null",
@@ -46,6 +49,9 @@ Array [
           "title": "donor01",
         },
       ],
+    },
+    Object {
+      "params": Object {},
     },
   ],
   Array [
@@ -66,6 +72,9 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {},
+    },
   ],
   Array [
     "/dev/null",
@@ -84,6 +93,9 @@ Array [
           "title": "donor03",
         },
       ],
+    },
+    Object {
+      "params": Object {},
     },
   ],
   Array [
@@ -104,6 +116,9 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {},
+    },
   ],
   Array [
     "/dev/null",
@@ -122,6 +137,9 @@ Array [
           "title": "donor05",
         },
       ],
+    },
+    Object {
+      "params": Object {},
     },
   ],
   Array [
@@ -142,6 +160,9 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {},
+    },
   ],
   Array [
     "/dev/null",
@@ -160,6 +181,9 @@ Array [
           "title": "donor07",
         },
       ],
+    },
+    Object {
+      "params": Object {},
     },
   ],
   Array [
@@ -180,6 +204,9 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {},
+    },
   ],
   Array [
     "/dev/null",
@@ -198,6 +225,9 @@ Array [
           "title": "donor09",
         },
       ],
+    },
+    Object {
+      "params": Object {},
     },
   ],
   Array [
@@ -218,6 +248,9 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {},
+    },
   ],
 ]
 `;
@@ -235,6 +268,9 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {},
+    },
   ],
   Array [
     "/dev/null",
@@ -246,6 +282,9 @@ Array [
           "title": undefined,
         },
       ],
+    },
+    Object {
+      "params": Object {},
     },
   ],
 ]
@@ -264,6 +303,11 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {
+        "q": "42",
+      },
+    },
   ],
   Array [
     "/dev/null",
@@ -275,6 +319,11 @@ Array [
           "title": "donor01",
         },
       ],
+    },
+    Object {
+      "params": Object {
+        "q": "42",
+      },
     },
   ],
   Array [
@@ -288,6 +337,11 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {
+        "q": "42",
+      },
+    },
   ],
   Array [
     "/dev/null",
@@ -299,6 +353,11 @@ Array [
           "title": "donor03",
         },
       ],
+    },
+    Object {
+      "params": Object {
+        "q": "42",
+      },
     },
   ],
   Array [
@@ -312,6 +371,11 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {
+        "q": "42",
+      },
+    },
   ],
   Array [
     "/dev/null",
@@ -323,6 +387,11 @@ Array [
           "title": "donor05",
         },
       ],
+    },
+    Object {
+      "params": Object {
+        "q": "42",
+      },
     },
   ],
   Array [
@@ -336,6 +405,11 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {
+        "q": "42",
+      },
+    },
   ],
   Array [
     "/dev/null",
@@ -347,6 +421,11 @@ Array [
           "title": "donor07",
         },
       ],
+    },
+    Object {
+      "params": Object {
+        "q": "42",
+      },
     },
   ],
   Array [
@@ -360,6 +439,11 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {
+        "q": "42",
+      },
+    },
   ],
   Array [
     "/dev/null",
@@ -372,6 +456,11 @@ Array [
         },
       ],
     },
+    Object {
+      "params": Object {
+        "q": "42",
+      },
+    },
   ],
   Array [
     "/dev/null",
@@ -383,6 +472,11 @@ Array [
           "title": "donor10",
         },
       ],
+    },
+    Object {
+      "params": Object {
+        "q": "42",
+      },
     },
   ],
 ]

--- a/__tests__/handlers.test.js
+++ b/__tests__/handlers.test.js
@@ -19,6 +19,7 @@ test("hook works (no mentions)", async () => {
   const ctx = {
     routes: { test: "/dev/null" },
     params: { slug: "test" },
+    query: { q: "42" },
 
     request: {
       body: {
@@ -41,6 +42,7 @@ test("hook works (missing annotations subfield)", async () => {
   const ctx = {
     routes: { test: "/dev/null" },
     params: { slug: "test" },
+    query: {},
 
     request: {
       body: {
@@ -79,6 +81,7 @@ test("hook works (mentions)", async () => {
   const ctx = {
     routes: { test: "/dev/null" },
     params: { slug: "test" },
+    query: {},
 
     request: {
       body: {
@@ -105,6 +108,7 @@ test("healthcheck works", async () => {
   const ctx = {
     routes: { test: "/dev/null" },
     params: { slug: "test" },
+    query: {},
   };
 
   axios.get.mockResolvedValue(null);

--- a/handlers.js
+++ b/handlers.js
@@ -72,7 +72,7 @@ async function handleHook(ctx) {
   }
 
   for (const body of objectsToSend) {
-    await axios.post(hook, body).catch((err) => {
+    await axios.post(hook, body, { params: ctx.query }).catch((err) => {
       ctx.status = 500;
       console.error(err);
       return;


### PR DESCRIPTION
Motivation: to provide `thread_id` via query params reusing the existing hooks.