### PR TITLE
feat: inline fields support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ will be used for title and description respectivelly.
 
 Look at [squirrelly](https://squirrelly.js.org) docs for templating reference.
 
+#### Inline fields
+
+Provide `inline_fields` alert's annotation to insert the inline fields with the values provided by the markdown list:
+
+```yaml
+inline_fields: |
+  - hello
+  - there
+```
+
 ## Release flow
 
 To create new release:

--- a/__tests__/__snapshots__/handlers.test.js.snap
+++ b/__tests__/__snapshots__/handlers.test.js.snap
@@ -8,6 +8,38 @@ Array [
 ]
 `;
 
+exports[`hook works (fields) 1`] = `
+Array [
+  Array [
+    "/dev/null",
+    Object {
+      "embeds": Array [
+        Object {
+          "color": 51283,
+          "description": undefined,
+          "fields": Array [
+            Object {
+              "inline": true,
+              "name": "",
+              "value": "**hello**",
+            },
+            Object {
+              "inline": true,
+              "name": "",
+              "value": "there",
+            },
+          ],
+          "title": "Obi-Wan Kenobi says",
+        },
+      ],
+    },
+    Object {
+      "params": Object {},
+    },
+  ],
+]
+`;
+
 exports[`hook works (mentions) 1`] = `
 Array [
   Array [

--- a/handlers.js
+++ b/handlers.js
@@ -1,7 +1,8 @@
 const axios = require("axios");
 const { compileTitle, compileDescr } = require("./templating");
+const marked = require("marked");
 
-const colors = { firing: 0xd50000, resolved: 0x00c853 };
+const colors = { firing: 0xd50000, resolved: 0x00c853, default: 0x333333 };
 
 function getMentions(alert) {
   const mentions = alert.labels["mentions"];
@@ -14,6 +15,60 @@ function getMentions(alert) {
     .split(",")
     .filter(Boolean)
     .map((m) => `<@${m}>`);
+}
+
+/**
+ * @typedef MarkedList
+ * @prop {Array.<{text: string}} items
+ */
+
+function getFields(alert) {
+  /** @type {string} */
+  const fields_markdown = alert.annotations?.inline_fields;
+  if (!fields_markdown) {
+    return [];
+  }
+
+  try {
+    const parsed = marked.lexer(fields_markdown);
+    /** @type {MarkedList?} */
+    const fields = parsed.filter((e) => e.type === "list").at(0);
+    validateFieldsList(fields);
+    return transformFieldsList(fields);
+  } catch (err) {
+    console.error(err);
+    return [];
+  }
+}
+
+/**
+ * @param {MarkedList?} list
+ */
+function validateFieldsList(list) {
+  const fields = list?.items?.map((e) => e.text);
+
+  if (!fields) {
+    throw new Error("Fields list is empty");
+  }
+
+  if (fields.length > 25) {
+    throw new Error("Too many fields");
+  }
+
+  fields.forEach((e) => {
+    if (e.length > 1024) {
+      throw new Error("Too many characters in a field");
+    }
+  });
+}
+
+/**
+ * @param {MarkedList} list
+ */
+function transformFieldsList(list) {
+  return list.items.map((e) => {
+    return { name: "", value: e.text.trim(), inline: true };
+  });
 }
 
 async function handleHook(ctx) {
@@ -45,7 +100,7 @@ async function handleHook(ctx) {
           {
             title: compileTitle(alert) || summary,
             description: compileDescr(alert) || description,
-            color: colors[alert.status],
+            color: colors[alert.status] || colors.default,
           },
         ],
       };
@@ -54,6 +109,11 @@ async function handleHook(ctx) {
       if (mentions.length) {
         body.allowed_mentions = { parse: ["users", "roles"] };
         body.content = mentions.join(" ");
+      }
+
+      const fields = getFields(alert);
+      if (fields.length) {
+        body.embeds.at(0).fields = fields;
       }
 
       objectsToSend.push(body);
@@ -116,4 +176,5 @@ module.exports = {
   handleHook,
   handleHealthcheck,
   getMentions,
+  getFields,
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "js-yaml": "^4.1.0",
     "koa": "^2.13.4",
     "koa-bodyparser": "^4.3.0",
+    "marked": "^5.0.2",
     "squirrelly": "^8.0.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2142,6 +2142,11 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+marked@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-5.0.2.tgz#ac79e78ea7ed9ad31de70b85e274595d9029e534"
+  integrity sha512-TXksm9GwqXCRNbFUZmMtqNLvy3K2cQHuWmyBDLOrY1e6i9UvZpOTJXoz7fBjYkJkaUFzV9hBFxMuZSyQt8R6KQ==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"


### PR DESCRIPTION
Add support for inline fields via providing a special annotation`inline_fields`. It accepts a plain list in markdown. Every list entry will be converted to an inline field with a `value` set to the entry text (markdown in the entry is preserved). Nested lists are treated as plain text.