### PR TITLE
feat: alerts batching configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ It will allow you to describe alerts in the following way:
 And it will produce the following result:
 ![img.png](.images/img.png)
 
+## Alerts batching
+
+It is possible to configure the number of records in one message of the Discord alert body, and the number of messages
+in the Discord alert. This is possible using the following environment variables:
+```yaml
+environment:
+  MAX_EMBEDS_LENGTH: 10
+  MAX_FIELDS_LENGTH: 25
+```
+The default values for these environment variables are 10 and 25 respectively.
+
 ## Release flow
 
 To create new release:

--- a/__tests__/handlers_default.test.js
+++ b/__tests__/handlers_default.test.js
@@ -194,19 +194,31 @@ test("getMentions works (valid label's value)", () => {
 });
 
 test("getFields works (no inline_fields)", () => {
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
   const fields = getFields({
     annotations: {},
-  });
+  }, logger);
 
   expect(fields.length).toBe(0);
 });
 
 test("getFields works (not a list)", () => {
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
   const fields = getFields({
     annotations: {
       inline_fields: "**hm**",
     },
-  });
+  }, logger);
 
   expect(fields.length).toBe(0);
 })

--- a/handlers_alternative.js
+++ b/handlers_alternative.js
@@ -1,8 +1,9 @@
 const axios = require("axios");
 
 const colors = { firing: 0xd50000, resolved: 0x00c853 };
-const maxEmbedsLength = 10;
-const maxFieldsLength = 25;
+const maxEmbedsLength = process.env.MAX_EMBEDS_LENGTH != null ? parseInt(process.env.MAX_EMBEDS_LENGTH, 10) : 10;
+const maxFieldsLength = process.env.MAX_FIELDS_LENGTH != null ? parseInt(process.env.MAX_FIELDS_LENGTH, 10) : 25;
+
 const groupBy = (array, func) => {
     return array.reduce((group, item) => {
         const groupName = func(item);


### PR DESCRIPTION
Now it is possible to configure the number of records in the Discord alert body and the number of batches in one Discord alert using env variables.